### PR TITLE
return `driver.ErrBadConn` if `Dial()` fails

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -77,6 +77,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		mc.netConn, err = nd.Dial(mc.cfg.Net, mc.cfg.Addr)
 	}
 	if err != nil {
+		errLog.Print("err from Dial()': ", err.Error())
 		return nil, driver.ErrBadConn
 	}
 

--- a/driver.go
+++ b/driver.go
@@ -77,7 +77,7 @@ func (d MySQLDriver) Open(dsn string) (driver.Conn, error) {
 		mc.netConn, err = nd.Dial(mc.cfg.Net, mc.cfg.Addr)
 	}
 	if err != nil {
-		return nil, err
+		return nil, driver.ErrBadConn
 	}
 
 	// Enable TCP Keepalives on TCP connections

--- a/driver_test.go
+++ b/driver_test.go
@@ -1801,6 +1801,23 @@ func TestConcurrent(t *testing.T) {
 	})
 }
 
+func TestDialErrBadConn(t *testing.T) {
+	RegisterDial("mydial", func(addr string) (net.Conn, error) {
+		return nil, fmt.Errorf("test")
+	})
+
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@mydial(%s)/%s?timeout=30s", user, pass, addr, dbname))
+	if err != nil {
+		t.Fatalf("error connecting: %s", err.Error())
+	}
+	defer db.Close()
+
+	_, err = db.Exec("DO 1")
+	if err != driver.ErrBadConn {
+		t.Fatalf("was expecting ErrBadConn. Got: %s", err)
+	}
+}
+
 // Tests custom dial functions
 func TestCustomDial(t *testing.T) {
 	if !available {


### PR DESCRIPTION
Because this error is retried in the driver and means the connection never succeeded.

Once this is merged I'll open the same thing on the official repo, and we can update our services to use this fork.

```
// ErrBadConn should be returned by a driver to signal to the sql
// package that a driver.Conn is in a bad state (such as the server
// having earlier closed the connection) and the sql package should
// retry on a new connection.
//
// To prevent duplicate operations, ErrBadConn should NOT be returned
// if there's a possibility that the database server might have
// performed the operation. Even if the server sends back an error,
// you shouldn't return ErrBadConn.
```

https://github.com/golang/go/blob/a0d6420d8be2ae7164797051ec74fa2a2df466a1/src/database/sql/driver/driver.go#L111-L119